### PR TITLE
Another CoinGate sad update

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Hosted payment processors run on someone else's server. This simplifies the init
 | Processor | Fees | Lightning | Directly to Your Wallet | Conversion to Fiat | Requirements |
 | --------- |:----:|:---------:|:-----------------------:|:------------------:| ------------ |
 | [Confirmo](https://confirmo.net/) | 0.8% | No | No | Yes | Information about business / website. May require certain documents. |
-| [CoinGate](https://coingate.com/accept-bitcoin) | 1% | Yes | No | Yes | Requires [a lot of information and business documents](https://blog.coingate.com/2019/05/verify-merchant-account-faq), officially translated in english. |
+| [CoinGate](https://coingate.com/accept-bitcoin) | 1% (merchant) + some [variable service fee](https://support.coingate.com/en/109/why-does-coingate-charge-service-fee) (customer) | Yes | No | Yes | Requires [a lot of information and business documents](https://blog.coingate.com/2019/05/verify-merchant-account-faq), officially translated in english. |
 | [CoinPayments](https://www.coinpayments.net/) | 0.5% | Yes | No | Yes | On withdrawal may require a number of forms of identification and will require settlement of any outstanding amounts. |
 | [GloBee](https://globee.com/) | 1% or ($30 - $300)/mo | Yes | No | Via [Luno](https://www.luno.com) and [Uphold](https://uphold.com/) | Information about business / website. May require certain documents. |
 | [OpenNode](https://www.opennode.co/) | 1% | Yes | No | Yes | May require to verify identity. Also may require to verify details or sources of funds regarding received payments. |


### PR DESCRIPTION
I just discovered CoinGate charges some variable "service fee" to the customer (0.5 - 3% in my tests) in addition to their fixed 1% merchant fee. They said it's to pay the miner fees for internal money transfer: https://support.coingate.com/en/109/why-does-coingate-charge-service-fee. They intentionally hide this fee from their [pricing page](https://coingate.com/pricing) (saying 1%, and "no hidden fees") and from the admin UI (leading to numbers which doesn't add up, they show the price paid by the custom, the 1% fee, and the result price which is actually lower by another 0.5-3%). I tried to ask their support but after countless messages trying to dodge the question they only said: "don't worry it's a fee paid by the customer, not the merchant". This is very misleading and worth nothing IMO, as the total "fee" paid by both customer and merchant (excluding the initial customer payment fees of course) is actually higher than 1%, more like 1.5% - 4% total fee in my tests (with transaction amounts from 5€ to 100€).