### PR TITLE
Add Bitrequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Hosted payment processors run on someone else's server. This simplifies the init
 | [Blockonomics](https://www.blockonomics.co/merchants) | 1% | No | Yes | Via [Payment Forwarding](https://www.blockonomics.co/views/payment_forwarding.html) | No |
 | [Bittery.io](https://bittery.io/) | No fees | Yes | Yes | Via [Payment Forwarding](https://www.blockonomics.co/views/payment_forwarding.html) and [Exchange Integration](https://redbtc.org/flows/integrations/kraken-exchange/) | No |
 | [Payscrypt](https://payscrypt.com/) | No fees | No | Yes | No | No |
+| [Bitrequest](https://bitrequest.io/) | No fees | No | Yes | No | No |
 
 ### Custodial
 


### PR DESCRIPTION
Bitrequest is a non-custodial crypto request app, which can be used as a point of sale, for sharing requests with your friends or as a payment processor for your webshop. Bitrequest is hosted on [github](https://bitrequest.github.io) but can also run on your server or desktop.  
Bitrequest supports BTC, LTC, DOGE, NANO, XMR, BCH, ETH and Erc-20.  
[bitrequest.io](https://www.bitrequest.io)